### PR TITLE
spec: add ASICBOOST mitigation

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -70,8 +70,8 @@ OP_RETURN 0x24 0xaa21a9ef[32-byte-merkle-root]
 The commitment serialization and discovery rules follows the same rules defined
 in BIP141.
 
-The merkle root is to be calculated as a merkle tree with all extension block
-txids and wtxids as the leaves.
+The merkle root is to be calculated as a merkle tree with all extension and
+canonical block txids and wtxids as the leaves.
 
 Note that canonical blocks containing entering outputs MUST contain an
 extension block commitment (all zeroes if nothing is present in the extension


### PR DESCRIPTION
Our current commitment scheme is vulnerable to the collision scheme exploited in ASICBOOST devices. It is an open question how this should be handled, but it does sound right to me that we should at least match SEGWIT's behavior to compete with it on fair grounds.

Calculating merkle-root over extension block transactions is not enough, since it still allows "shaking" the TX list in the canonical block without changing the commitment.