### PR TITLE
spec: implement compatibility with segwit.

### DIFF
--- a/spec-p2p.md
+++ b/spec-p2p.md
@@ -22,27 +22,20 @@ extension blocks is supported by the remote node.
 
 ### Block and transaction relay
 
-This specification defines new INV types for GETDATA requests. Similar to the
-INV types defined in BIP144, an `extended bit` is to be set on both `tx` and
-`block` inv types. The extended bit exists as the 30th bit, e.g. `1` would
-become `536870913` (`(1 << 29) | 1`).
-
-Newly defined inv types are as follows:
-
-- `EXT_TX`: `536870913` (`(1 << 29) | 1`)
-- `EXT_BLOCK`: `536870914` (`(1 << 29) | 2`)
+The extension block shall be delivered in the same payload as a canonical block
+in the case of a `GETDATA` message with an inv type of `WITNESS_BLOCK`.
 
 #### Backward Compatability
 
 To avoid an enormous amount of orphan transactions on non-upgraded nodes,
-upgraded nodes shall respond with a NOTFOUND message in response to any regular
-GETDATA TX request which maps to an extension chain transaction. Invs
+upgraded nodes shall respond with a `NOTFOUND` message in response to any
+regular `GETDATA TX` request which maps to an extension chain transaction. Invs
 containing extension transactions shall not be broadcast to non-upgraded peers.
 
-Responses GETDATA EXT_TX shall include both extension and non-extension
-transactions.
+Responses to a `GETDATA` message with an inv type of `WITNESS_TX` shall include
+both extension and non-extension transactions.
 
-### `EXT_BLOCK` message serialization
+### Extra `WITNESS_BLOCK` message serialization
 
 `block` messages requested with the `EXT_BLOCK` inv type are to use the
 canonical serialization with an extra varint count appended. Following the
@@ -50,12 +43,20 @@ varint count shall be a transaction vector using BIP141 serialization. Clients
 MUST disregard blocks which use BIP141 serialization in the canonical
 transaction vector.
 
+In other words, extension block payloads are combined with a canonical block
+payload, in the form of:
+
+```
+[80-byte header]
+[varint tx count]
+[tx vector]
+[varint extension tx count]
+[extension tx vector]
+```
+
 ### Extensions to Compact Block Relay (BIP152)
 
-Compact block relay shall be initiated using the previously specified (BIP152)
-`sendcmpct` message, with a version of `3`. Serialization for `cmpctblock`,
-`blocktxnrequest`, and `blocktxn` are modified to include two transaction
-vectors. The first being canonical, and the second being extended.
+TODO.
 
 ## Reference Implementation
 


### PR DESCRIPTION
This is something I've considered for a while. I've been thinking about it more frequently for the past week or two: mainchain segwit adds a few benefits to extblk. The exclusion of mainchain segwit wasn't a very conscious technical decision initially. It was just the simplest path for the code at the time, and less complexity. I think this decision should be reexamined technically for this reason.

I've revised some major parts of the specification, mostly pertaining to how entrance into and exits from the extension block behave. The new behavior is similar to Johnson's [2017 proposal][ext]. Listing changes and potential benefits here.

### Changes

#### Consensus

- The extblk deployment now depends on the segwit deployment. This is a side effect of using witness programs as entrances/exits (both deployments need to be able to coexist in this setup).
- The commitment magic number has been changed from `0xaa21a9ef` to `0x45424c4b` (ascii: EBLK). This is to avoid confusion.
- The commitment itself no longer includes canonical block txids, since this is already included by the segwit commitment.
- Entrances into the extension block must be witness programs v9 through v16.  These are reserved ahead of time so the protocol knows which outputs need to enter/exit. The first defined witness programs will be v9, replicating the current v0 programs.
- Exits from the extension block must only be witness programs v0-v8. This is probably the biggest benefit of including mainchain segwit, and mitigates potential [edge cases with legacy wallets][ml] trying to spend early from a resolution output (segwit-enabled wallets should be aware of the new maturity rule). See #9. cc @jl2012

#### P2P

- The extension block payload is now always delivered when a `getdata` inv type is used with the witness bit.
- Extension transactions are now always delivered with the `getdata` witness bit.
- The witness service bit could potentially be used to signal both extblk+segwit support, since (I think) trailing bytes on a block message are simply ignored by a lot of implementations (someone please correct me here if I'm wrong). Backward compatibility is sort of built-in.

#### Policy

- We can now drop the notion of a mempool nursery for early resolution spends (mentioned elsewhere). The mempool will simply reject early spends of resolution outputs. This ensures segwit wallets won't mistakenly see an early spend of a resolution output coming to them, and in turn also mistakenly spend from that.

### Other considerations / Todo

- SIGHASH_NOINPUT (as described in the [LN paper][ln]) could potentially be implemented in segwit's sighash algorithm. This requires for a modification to mainchain segwit (either in a new wit program or in v0 if the deployment is renewed), but could allow for safe early spends of resolution outputs (with some caveats). It also adds the potential for Lightning outsourcing features -- for this purpose, we could have it in the extension block right off the bat.
- A non-contextual check for which chain the transaction resides in could (should?) be added. I'm thinking of two methods. Either:
  - Transactions within the extension block must have the second segwit `flags` bit set to `1` (implementations must now track this). This gives an easy non-contextual check for which chain the transaction is in, which has nice implications for wallets and protocols like compact block relay. Note that the flags byte is malleable in the mempool. I also don't think the flag byte was intended to be used this way, but rather for future serialization changes.
  - Transactions within the extension block must have a high version bit set.  This has similar implications to the flag bit, without the malleability problem since the version is signed. The issue here is that it makes some parts of code less reusable, since we'll have to and off the low bits to see the "real" version number. This also requires a new rule requiring this bit to never be used on the canonical chain.

I have a preliminary reference implementation here: https://github.com/bcoin-org/bcoin-extension-blocks/tree/extblk-sw2. Everything outlined above is more or less present, but the code still needs some work and more tests.

If consider this route, I think we can have extnet2 up in a reasonable amount of time to play around with this.

Opening it up for discussion. Thoughts?

cc @gasteve @josephpoon

[ln]: https://lightning.network/lightning-network-paper.pdf
[ml]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-April/014124.html
[ext]: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-January/013490.html